### PR TITLE
HACK: Pin bokeh version (Q2 2018.6)

### DIFF
--- a/2018.6/release/qiime2-2018.6-py35-linux-conda.yml
+++ b/2018.6/release/qiime2-2018.6-py35-linux-conda.yml
@@ -38,7 +38,7 @@ dependencies:
 - backcall=0.1.0
 - bibtexparser=1.0.1
 - bleach=2.1.3
-- bokeh=0.12.16
+- bokeh=0.12.15
 - boost=1.64.0
 - boost-cpp=1.64.0
 - bzip2=1.0.6

--- a/2018.6/release/qiime2-2018.6-py35-osx-conda.yml
+++ b/2018.6/release/qiime2-2018.6-py35-osx-conda.yml
@@ -39,7 +39,7 @@ dependencies:
 - backcall=0.1.0
 - bibtexparser=1.0.1
 - bleach=2.1.3
-- bokeh=0.12.16
+- bokeh=0.12.15
 - ca-certificates=2018.4.16
 - cachecontrol=0.12.4
 - cairo=1.14.10

--- a/2018.6/staging/qiime2-2018.6-py35-linux-conda.yml
+++ b/2018.6/staging/qiime2-2018.6-py35-linux-conda.yml
@@ -38,7 +38,7 @@ dependencies:
 - backcall=0.1.0
 - bibtexparser=1.0.1
 - bleach=2.1.3
-- bokeh=0.12.16
+- bokeh=0.12.15
 - boost=1.64.0
 - boost-cpp=1.64.0
 - bzip2=1.0.6

--- a/2018.6/staging/qiime2-2018.6-py35-osx-conda.yml
+++ b/2018.6/staging/qiime2-2018.6-py35-osx-conda.yml
@@ -39,7 +39,7 @@ dependencies:
 - backcall=0.1.0
 - bibtexparser=1.0.1
 - bleach=2.1.3
-- bokeh=0.12.16
+- bokeh=0.12.15
 - ca-certificates=2018.4.16
 - cachecontrol=0.12.4
 - cairo=1.14.10


### PR DESCRIPTION
Manually pin bokeh version in 2018.6 env files, as suggested here: https://github.com/qiime2/q2-composition/issues/56#issuecomment-407476989